### PR TITLE
feat: Add conversation logging system with shell alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .nyc_output/
 data/
 temp/
+conversation-log.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,17 @@
 - Main commands are under `team coda` namespace
 - Data extraction and RAG (Retrieval-Augmented Generation) services are available
 
+## Conversation Logging
+- **ALWAYS** maintain an ongoing log of our chat conversations
+- Record user queries in their entirety with timestamps
+- Record Claude Code responses (first/last lines or summary) grouped with each query
+- Log all significant commands executed
+- Use this log as context across different conversations to maintain continuity
+- Store conversation logs to help track project evolution and decision history
+- **Format:** `**HH:MM:SS** User: [query]` followed by `Claude: [response summary]`
+- **Sessions:** Track new chat sessions with `### Session N` headers
+- **Log file location:** `conversation-log.md` (root of project, excluded from git)
+
 ## Commands to Remember
 - Build project: `npm run build`
 - Lint/typecheck: Check package.json scripts for available lint commands

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -1,0 +1,23 @@
+# Useful Shell Aliases
+
+## Claude Code Aliases
+
+### claude-log
+Starts Claude Code with automatic logging instructions:
+
+```bash
+alias claude-log='claude "Read CLAUDE.md instructions and update conversation-log.md as we chat"'
+```
+
+**Usage:** `claude-log`
+
+**What it does:**
+- Starts Claude Code normally
+- Automatically sends the logging instruction as the first message
+- Ensures Claude reads project context from CLAUDE.md
+- Maintains conversation history in conversation-log.md
+
+**Setup:**
+Add this alias to your `~/.bashrc` or `~/.zshrc` file, then reload your shell or run `source ~/.bashrc`/`source ~/.zshrc`.
+
+This helps maintain conversation continuity across Claude Code sessions by ensuring logging instructions are followed consistently.


### PR DESCRIPTION
## Summary
- Implement structured conversation logging to maintain context across Claude Code sessions
- Move CLAUDE.md to project root for better integration with Claude Code
- Add claude-log shell alias for automatic logging setup

## Changes
- **CLAUDE.md**: Moved from docs/ to root, added conversation logging instructions
- **docs/aliases.md**: New documentation for claude-log shell alias
- **.gitignore**: Added conversation-log.md to keep logs private
- **Logging format**: Timestamps for user queries, grouped responses, session tracking

## Benefits  
- Maintains conversation context across different Claude Code sessions
- Automatic logging setup via shell alias
- Structured format for easy reference and project continuity

## Test plan
- [x] Verify CLAUDE.md is read by Claude Code in new sessions
- [x] Test claude-log alias functionality
- [x] Confirm conversation-log.md is properly ignored by git

🤖 Generated with [Claude Code](https://claude.ai/code)